### PR TITLE
[EDU-6371]  Replace domain with Workload in frameworks docs

### DIFF
--- a/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-angular.mdx
+++ b/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-angular.mdx
@@ -120,9 +120,9 @@ azion deploy
 Once the deployment is triggered, Azion will open the browser and take the user to a page on Azion Console where the deployment logs and process can be monitored. If it doesn't open automatically, just click on the provided link.
 ::: 
 
-After the deployment is complete, you'll receive a domain to access your Angular project on the Azion's platform.
+After the deployment is complete, you'll receive a Workload to access your Angular project on the Azion's platform.
 
-Wait a few minutes so the propagation takes place, and then access your application using the provided domain, which should be similar to `https://xxxxxxx.map.azionedge.net`.
+Wait a few minutes so the propagation takes place, and then access your application using the provided Workload, which should be similar to `https://xxxxxxx.map.azionedge.net`.
 
 ### Answering no to local dev
 
@@ -146,9 +146,9 @@ After indicating you don't want to have a local server running, deploy the Angul
 Once the deployment is triggered, Azion will open the browser and take the user to a page on Azion Console where the deployment logs and process can be monitored. If it doesn't open automatically, just click on the provided link.
 ::: 
 
-After the deployment is complete, you'll receive a domain to access your Angular project on the Azion Platform.
+After the deployment is complete, you'll receive a Workload to access your Angular project on the Azion Platform.
 
-Wait a few minutes so the propagation takes place, and then access your application using the provided domain, which should be similar to `https://xxxxxxx.map.azionedge.net`.
+Wait a few minutes so the propagation takes place, and then access your application using the provided Workload, which should be similar to `https://xxxxxxx.map.azionedge.net`.
 
 Learn how to build with Angular. Watch the video below:
 <div class="cms-embed">

--- a/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-astro.mdx
+++ b/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-astro.mdx
@@ -129,9 +129,9 @@ azion deploy
 Once the deployment is triggered, Azion will open the browser and take the user to a page on Azion Console where the deployment logs and process can be monitored. If it doesn't open automatically, just click on the provided link.
 ::: 
 
-After the deployment is complete, you'll receive a domain to access your Astro project on the Azion's platform.
+After the deployment is complete, you'll receive a Workload to access your Astro project on the Azion's platform.
 
-Wait a few minutes so the propagation takes place, and then access your application using the provided domain, which should be similar to `https://xxxxxxx.map.azionedge.net`.
+Wait a few minutes so the propagation takes place, and then access your application using the provided Workload, which should be similar to `https://xxxxxxx.map.azionedge.net`.
 
 ### Answering no to local dev
 
@@ -155,9 +155,9 @@ After indicating you don't want to have a local server running, deploy the Astro
 Once the deployment is triggered, Azion will open the browser and take the user to a page on Azion Console where the deployment logs and process can be monitored. If it doesn't open automatically, just click on the provided link.
 ::: 
 
-After the deployment is complete, you'll receive a domain to access your Astro project on the Azion Platform.
+After the deployment is complete, you'll receive a Workload to access your Astro project on the Azion Platform.
 
-Wait a few minutes so the propagation takes place, and then access your application using the provided domain, which should be similar to `https://xxxxxxx.map.azionedge.net`.
+Wait a few minutes so the propagation takes place, and then access your application using the provided Workload, which should be similar to `https://xxxxxxx.map.azionedge.net`.
 
 Watch an Astro building guide on Azion's YouTube channel:
 

--- a/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-docusaurus.mdx
+++ b/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-docusaurus.mdx
@@ -124,9 +124,9 @@ azion deploy
 Once the deployment is triggered, Azion will open the browser and take the user to a page on Azion Console where the deployment logs and process can be monitored. If it doesn't open automatically, just click on the provided link.
 ::: 
 
-After the deployment is complete, you'll receive a domain to access your Docusaurus project on the Azion's platform.
+After the deployment is complete, you'll receive a Workload to access your Docusaurus project on the Azion's platform.
 
-Wait a few minutes so the propagation takes place, and then access your application using the provided domain, which should be similar to `https://xxxxxxx.map.azionedge.net`.
+Wait a few minutes so the propagation takes place, and then access your application using the provided Workload, which should be similar to `https://xxxxxxx.map.azionedge.net`.
 
 ### Answering no to local dev
 
@@ -150,6 +150,6 @@ After indicating you don't want to have a local server running, deploy the Docus
 Once the deployment is triggered, Azion will open the browser and take the user to a page on Azion Console where the deployment logs and process can be monitored. If it doesn't open automatically, just click on the provided link.
 ::: 
 
-After the deployment is complete, you'll receive a domain to access your Docusaurus project on the Azion Platform.
+After the deployment is complete, you'll receive a Workload to access your Docusaurus project on the Azion Platform.
 
-Wait a few minutes so the propagation takes place, and then access your application using the provided domain, which should be similar to `https://xxxxxxx.map.azionedge.net`.
+Wait a few minutes so the propagation takes place, and then access your application using the provided Workload, which should be similar to `https://xxxxxxx.map.azionedge.net`.

--- a/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-eleventy.mdx
+++ b/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-eleventy.mdx
@@ -124,9 +124,9 @@ azion deploy
 Once the deployment is triggered, Azion will open the browser and take the user to a page on Azion Console where the deployment logs and process can be monitored. If it doesn't open automatically, just click on the provided link.
 ::: 
 
-After the deployment is complete, you'll receive a domain to access your Eleventy project on the Azion's platform.
+After the deployment is complete, you'll receive a Workload to access your Eleventy project on the Azion's platform.
 
-Wait a few minutes so the propagation takes place, and then access your application using the provided domain, which should be similar to `https://xxxxxxx.map.azionedge.net`.
+Wait a few minutes so the propagation takes place, and then access your application using the provided Workload, which should be similar to `https://xxxxxxx.map.azionedge.net`.
 
 ### Answering no to local dev
 
@@ -150,6 +150,6 @@ After indicating you don't want to have a local server running, deploy the Eleve
 Once the deployment is triggered, Azion will open the browser and take the user to a page on Azion Console where the deployment logs and process can be monitored. If it doesn't open automatically, just click on the provided link.
 ::: 
 
-After the deployment is complete, you'll receive a domain to access your Eleventy project on the Azion Platform.
+After the deployment is complete, you'll receive a Workload to access your Eleventy project on the Azion Platform.
 
-Wait a few minutes so the propagation takes place, and then access your application using the provided domain, which should be similar to `https://xxxxxxx.map.azionedge.net`.
+Wait a few minutes so the propagation takes place, and then access your application using the provided Workload, which should be similar to `https://xxxxxxx.map.azionedge.net`.

--- a/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-gatsby.mdx
+++ b/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-gatsby.mdx
@@ -124,9 +124,9 @@ azion deploy
 Once the deployment is triggered, Azion will open the browser and take the user to a page on Azion Console where the deployment logs and process can be monitored. If it doesn't open automatically, just click on the provided link.
 ::: 
 
-After the deployment is complete, you'll receive a domain to access your Gatsby project on the Azion's platform.
+After the deployment is complete, you'll receive a Workload to access your Gatsby project on the Azion's platform.
 
-Wait a few minutes so the propagation takes place, and then access your application using the provided domain, which should be similar to `https://xxxxxxx.map.azionedge.net`.
+Wait a few minutes so the propagation takes place, and then access your application using the provided Workload, which should be similar to `https://xxxxxxx.map.azionedge.net`.
 
 ### Answering no to local dev
 
@@ -150,6 +150,6 @@ After indicating you don't want to have a local server running, deploy the Gatsb
 Once the deployment is triggered, Azion will open the browser and take the user to a page on Azion Console where the deployment logs and process can be monitored. If it doesn't open automatically, just click on the provided link.
 ::: 
 
-After the deployment is complete, you'll receive a domain to access your Gatsby project on the Azion Platform.
+After the deployment is complete, you'll receive a Workload to access your Gatsby project on the Azion Platform.
 
-Wait a few minutes so the propagation takes place, and then access your application using the provided domain, which should be similar to `https://xxxxxxx.map.azionedge.net`.
+Wait a few minutes so the propagation takes place, and then access your application using the provided Workload, which should be similar to `https://xxxxxxx.map.azionedge.net`.

--- a/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-hexo.mdx
+++ b/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-hexo.mdx
@@ -125,9 +125,9 @@ azion deploy
 Once the deployment is triggered, Azion will open the browser and take the user to a page on Azion Console where the deployment logs and process can be monitored. If it doesn't open automatically, just click on the provided link.
 ::: 
 
-After the deployment is complete, you'll receive a domain to access your Hexo project on the Azion Platform.
+After the deployment is complete, you'll receive a Workload to access your Hexo project on the Azion Platform.
 
-Wait a few minutes so the propagation takes place, and then access your application using the provided domain, which should be similar to `https://xxxxxxx.map.azionedge.net`.
+Wait a few minutes so the propagation takes place, and then access your application using the provided Workload, which should be similar to `https://xxxxxxx.map.azionedge.net`.
 
 ### Answering no to local dev
 
@@ -151,9 +151,9 @@ Now, after indicating you don't want to have a local server running, deploy your
 Once the deployment is triggered, Azion will open the browser and take the user to a page on Azion Console where the deployment logs and process can be monitored. If it doesn't open automatically, just click on the provided link.
 ::: 
 
-After the deployment is complete, you'll receive a domain to access your Hexo project on the Azion Platform.
+After the deployment is complete, you'll receive a Workload to access your Hexo project on the Azion Platform.
 
-Wait a few minutes so the propagation takes place, and then access your application using the provided domain, which should be similar to `https://xxxxxxx.map.azionedge.net`.
+Wait a few minutes so the propagation takes place, and then access your application using the provided Workload, which should be similar to `https://xxxxxxx.map.azionedge.net`.
 
 Learn how to build with Hexo. Watch the video below:
 <div class="cms-embed">

--- a/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-hono.mdx
+++ b/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-hono.mdx
@@ -124,9 +124,9 @@ azion deploy
 Once the deployment is triggered, Azion will open the browser and take the user to a page on Azion Console where the deployment logs and process can be monitored. If it doesn't open automatically, just click on the provided link.
 ::: 
 
-After the deployment is complete, you'll receive a domain to access your Hono project on the Azion's platform.
+After the deployment is complete, you'll receive a Workload to access your Hono project on the Azion's platform.
 
-Wait a few minutes so the propagation takes place, and then access your application using the provided domain, which should be similar to `https://xxxxxxx.map.azionedge.net`.
+Wait a few minutes so the propagation takes place, and then access your application using the provided Workload, which should be similar to `https://xxxxxxx.map.azionedge.net`.
 
 ### Answering no to local dev
 
@@ -150,6 +150,6 @@ After indicating you don't want to have a local server running, deploy the Hono 
 Once the deployment is triggered, Azion will open the browser and take the user to a page on Azion Console where the deployment logs and process can be monitored. If it doesn't open automatically, just click on the provided link.
 ::: 
 
-After the deployment is complete, you'll receive a domain to access your Hono project on the Azion Platform.
+After the deployment is complete, you'll receive a Workload to access your Hono project on the Azion Platform.
 
-Wait a few minutes so the propagation takes place, and then access your application using the provided domain, which should be similar to `https://xxxxxxx.map.azionedge.net`.
+Wait a few minutes so the propagation takes place, and then access your application using the provided Workload, which should be similar to `https://xxxxxxx.map.azionedge.net`.

--- a/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-hugo.mdx
+++ b/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-hugo.mdx
@@ -124,9 +124,9 @@ azion deploy
 Once the deployment is triggered, Azion will open the browser and take the user to a page on Azion Console where the deployment logs and process can be monitored. If it doesn't open automatically, just click on the provided link.
 ::: 
 
-After the deployment is complete, you'll receive a domain to access your Hugo project on the Azion's platform.
+After the deployment is complete, you'll receive a Workload to access your Hugo project on the Azion's platform.
 
-Wait a few minutes so the propagation takes place, and then access your application using the provided domain, which should be similar to `https://xxxxxxx.map.azionedge.net`.
+Wait a few minutes so the propagation takes place, and then access your application using the provided Workload, which should be similar to `https://xxxxxxx.map.azionedge.net`.
 
 ### Answering no to local dev
 
@@ -150,6 +150,6 @@ After indicating you don't want to have a local server running, deploy the Hugo 
 Once the deployment is triggered, Azion will open the browser and take the user to a page on Azion Console where the deployment logs and process can be monitored. If it doesn't open automatically, just click on the provided link.
 ::: 
 
-After the deployment is complete, you'll receive a domain to access your Hugo project on the Azion Platform.
+After the deployment is complete, you'll receive a Workload to access your Hugo project on the Azion Platform.
 
-Wait a few minutes so the propagation takes place, and then access your application using the provided domain, which should be similar to `https://xxxxxxx.map.azionedge.net`.
+Wait a few minutes so the propagation takes place, and then access your application using the provided Workload, which should be similar to `https://xxxxxxx.map.azionedge.net`.

--- a/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-jekyll.mdx
+++ b/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-jekyll.mdx
@@ -127,9 +127,9 @@ azion deploy
 Once the deployment is triggered, Azion will open the browser and take the user to a page on Azion Console where the deployment logs and process can be monitored. If it doesn't open automatically, just click on the provided link.
 ::: 
 
-After the deployment is complete, you'll receive a domain to access your Jekyll project on the Azion's platform.
+After the deployment is complete, you'll receive a Workload to access your Jekyll project on the Azion's platform.
 
-Wait a few minutes so the propagation takes place, and then access your application using the provided domain, which should be similar to `https://xxxxxxx.map.azionedge.net`.
+Wait a few minutes so the propagation takes place, and then access your application using the provided Workload, which should be similar to `https://xxxxxxx.map.azionedge.net`.
 
 ### Answering no to local dev
 
@@ -153,6 +153,6 @@ After indicating you don't want to have a local server running, deploy the Jekyl
 Once the deployment is triggered, Azion will open the browser and take the user to a page on Azion Console where the deployment logs and process can be monitored. If it doesn't open automatically, just click on the provided link.
 ::: 
 
-After the deployment is complete, you'll receive a domain to access your Jekyll project on the Azion Platform.
+After the deployment is complete, you'll receive a Workload to access your Jekyll project on the Azion Platform.
 
-Wait a few minutes so the propagation takes place, and then access your application using the provided domain, which should be similar to `https://xxxxxxx.map.azionedge.net`.
+Wait a few minutes so the propagation takes place, and then access your application using the provided Workload, which should be similar to `https://xxxxxxx.map.azionedge.net`.

--- a/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-next.mdx
+++ b/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-next.mdx
@@ -126,9 +126,9 @@ azion deploy
 Once the deployment is triggered, Azion will open the browser and take the user to a page on Azion Console where the deployment logs and process can be monitored. If it doesn't open automatically, just click on the provided link.
 :::
 
-After the deployment is complete, you'll receive a domain to access your Next project on the Azion's platform.
+After the deployment is complete, you'll receive a Workload to access your Next project on the Azion's platform.
 
-Wait a few minutes so the propagation takes place, and then access your application using the provided domain, which should be similar to `https://xxxxxxx.map.azionedge.net`.
+Wait a few minutes so the propagation takes place, and then access your application using the provided Workload, which should be similar to `https://xxxxxxx.map.azionedge.net`.
 
 ### Answering no to local dev
 
@@ -152,9 +152,9 @@ Now, after indicating you don't want to have a local server running, deploy your
 Once the deployment is triggered, Azion will open the browser and take the user to a page on Azion Console where the deployment logs and process can be monitored. If it doesn't open automatically, just click on the provided link.
 ::: 
 
-After the deployment is complete, you'll receive a domain to access your Next project on the Azion's platform.
+After the deployment is complete, you'll receive a Workload to access your Next project on the Azion's platform.
 
-Wait a few minutes so the propagation takes place, and then access your application using the provided domain, which should be similar to `https://xxxxxxx.map.azionedge.net`.
+Wait a few minutes so the propagation takes place, and then access your application using the provided Workload, which should be similar to `https://xxxxxxx.map.azionedge.net`.
 
 ---
 

--- a/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-react.mdx
+++ b/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-react.mdx
@@ -132,9 +132,9 @@ azion deploy
 Once the deployment is triggered, Azion will open the browser and take the user to a page on Azion Console where the deployment logs and process can be monitored. If it doesn't open automatically, just click on the provided link.
 ::: 
 
-After the deployment is complete, you'll receive a domain to access your React project on the Azion Platform.
+After the deployment is complete, you'll receive a Workload to access your React project on the Azion Platform.
 
-Wait a few minutes so the propagation takes place, and then access your application using the provided domain, which should be similar to `https://xxxxxxx.map.azionedge.net`.
+Wait a few minutes so the propagation takes place, and then access your application using the provided Workload, which should be similar to `https://xxxxxxx.map.azionedge.net`.
 
 ### Answering no to local dev
 
@@ -158,9 +158,9 @@ Now, after indicating you don't want to have a local server running, deploy your
 Once the deployment is triggered, Azion will open the browser and take the user to a page on Azion Console where the deployment logs and process can be monitored. If it doesn't open automatically, just click on the provided link.
 ::: 
 
-After the deployment is complete, you'll receive a domain to access your React project on the Azion's platform.
+After the deployment is complete, you'll receive a Workload to access your React project on the Azion's platform.
 
-Wait a few minutes so the propagation takes place, and then access your application using the provided domain, which should be similar to `https://xxxxxxx.map.azionedge.net`.
+Wait a few minutes so the propagation takes place, and then access your application using the provided Workload, which should be similar to `https://xxxxxxx.map.azionedge.net`.
 
 Learn how to build with React. Watch the video below:
 <div class="cms-embed">

--- a/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-svelte.mdx
+++ b/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-svelte.mdx
@@ -131,9 +131,9 @@ azion deploy
 Once the deployment is triggered, Azion will open the browser and take the user to a page on Azion Console where the deployment logs and process can be monitored. If it doesn't open automatically, just click on the provided link.
 ::: 
 
-After the deployment is complete, you'll receive a domain to access your Svelte project on the Azion's platform.
+After the deployment is complete, you'll receive a Workload to access your Svelte project on the Azion's platform.
 
-Wait a few minutes so the propagation takes place, and then access your application using the provided domain, which should be similar to `https://xxxxxxx.map.azionedge.net`.
+Wait a few minutes so the propagation takes place, and then access your application using the provided Workload, which should be similar to `https://xxxxxxx.map.azionedge.net`.
 
 ### Answering no to local dev
 
@@ -157,6 +157,6 @@ After indicating you don't want to have a local server running, deploy the Svelt
 Once the deployment is triggered, Azion will open the browser and take the user to a page on Azion Console where the deployment logs and process can be monitored. If it doesn't open automatically, just click on the provided link.
 ::: 
 
-After the deployment is complete, you'll receive a domain to access your Svelte project on the Azion Platform.
+After the deployment is complete, you'll receive a Workload to access your Svelte project on the Azion Platform.
 
-Wait a few minutes so the propagation takes place, and then access your application using the provided domain, which should be similar to `https://xxxxxxx.map.azionedge.net`.
+Wait a few minutes so the propagation takes place, and then access your application using the provided Workload, which should be similar to `https://xxxxxxx.map.azionedge.net`.

--- a/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-vite.mdx
+++ b/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-vite.mdx
@@ -132,9 +132,9 @@ azion deploy
 Once the deployment is triggered, Azion will open the browser and take the user to a page on Azion Console where the deployment logs and process can be monitored. If it doesn't open automatically, just click on the provided link.
 ::: 
 
-After the deployment is complete, you'll receive a domain to access your VitePress project on the Azion's platform.
+After the deployment is complete, you'll receive a Workload to access your VitePress project on the Azion's platform.
 
-Wait a few minutes so the propagation takes place, and then access your application using the provided domain, which should be similar to `https://xxxxxxx.map.azionedge.net`.
+Wait a few minutes so the propagation takes place, and then access your application using the provided Workload, which should be similar to `https://xxxxxxx.map.azionedge.net`.
 
 ### Answering no to local dev
 
@@ -158,6 +158,6 @@ Now, after indicating you don't want to have a local server running, deploy your
 Once the deployment is triggered, Azion will open the browser and take the user to a page on Azion Console where the deployment logs and process can be monitored. If it doesn't open automatically, just click on the provided link.
 ::: 
 
-After the deployment is complete, you'll receive a domain to access your VitePress project on the Azion's platform.
+After the deployment is complete, you'll receive a Workload to access your VitePress project on the Azion's platform.
 
-Wait a few minutes so the propagation takes place, and then access your application using the provided domain, which should be similar to `https://xxxxxxx.map.azionedge.net`.
+Wait a few minutes so the propagation takes place, and then access your application using the provided Workload, which should be similar to `https://xxxxxxx.map.azionedge.net`.

--- a/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-vue.mdx
+++ b/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-vue.mdx
@@ -130,9 +130,9 @@ azion deploy
 Once the deployment is triggered, Azion will open the browser and take the user to a page on Azion Console where the deployment logs and process can be monitored. If it doesn't open automatically, just click on the provided link.
 :::
 
-After the deployment is complete, you'll receive a domain to access your Vue project on the Azion's platform.
+After the deployment is complete, you'll receive a Workload to access your Vue project on the Azion's platform.
 
-Wait a few minutes so the propagation takes place, and then access your application using the provided domain, which should be similar to `https://xxxxxxx.map.azionedge.net`.
+Wait a few minutes so the propagation takes place, and then access your application using the provided Workload, which should be similar to `https://xxxxxxx.map.azionedge.net`.
 
 ### Answering no to local dev
 
@@ -156,9 +156,9 @@ Now, after indicating you don't want to have a local server running, deploy your
 Once the deployment is triggered, Azion will open the browser and take the user to a page on Azion Console where the deployment logs and process can be monitored. If it doesn't open automatically, just click on the provided link.
 ::: 
 
-After the deployment is complete, you'll receive a domain to access your Vue project on the Azion's platform.
+After the deployment is complete, you'll receive a Workload to access your Vue project on the Azion's platform.
 
-Wait a few minutes so the propagation takes place, and then access your application using the provided domain, which should be similar to `https://xxxxxxx.map.azionedge.net`.
+Wait a few minutes so the propagation takes place, and then access your application using the provided Workload, which should be similar to `https://xxxxxxx.map.azionedge.net`.
 
 Learn how to build with Vue. Watch the video below:
 <div class="cms-embed">

--- a/src/content/docs/pt-br/pages/build-jornada/desenvolva-com-azion/guias-frameworks/framework-angular.mdx
+++ b/src/content/docs/pt-br/pages/build-jornada/desenvolva-com-azion/guias-frameworks/framework-angular.mdx
@@ -118,9 +118,9 @@ azion deploy
 Uma vez que o deployment é iniciado, a Azion abrirá o navegador e levará o usuário a uma página no Azion Console onde os logs e o processo de implantação podem ser monitorados. Se não abrir automaticamente, basta clicar no link fornecido.
 ::: 
 
-Após a implantação ser concluída, você receberá um domínio para acessar o seu projeto Angular na plataforma da Azion.
+Após a implantação ser concluída, você receberá um Workload para acessar o seu projeto Angular na plataforma da Azion.
 
-Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o domínio fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
+Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o Workload fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
 
 ### Resposta não para desenvolvimento local
 
@@ -144,6 +144,6 @@ Do you want to install project dependencies? This may be required to start local
 Uma vez que o deployment é iniciado, a Azion abrirá o navegador e levará o usuário a uma página no Azion Console onde os logs e o processo de implantação podem ser monitorados. Se não abrir automaticamente, basta clicar no link fornecido.
 ::: 
 
-Após a implantação ser concluída, você receberá um domínio para acessar o seu projeto Angular na Plataforma da Azion.
+Após a implantação ser concluída, você receberá um Workload para acessar o seu projeto Angular na Plataforma da Azion.
 
-Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o domínio fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
+Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o Workload fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.

--- a/src/content/docs/pt-br/pages/build-jornada/desenvolva-com-azion/guias-frameworks/framework-astro.mdx
+++ b/src/content/docs/pt-br/pages/build-jornada/desenvolva-com-azion/guias-frameworks/framework-astro.mdx
@@ -124,9 +124,9 @@ azion deploy
 Uma vez que o deployment é iniciado, a Azion abrirá o navegador e levará o usuário a uma página no Azion Console onde os logs e o processo de implantação podem ser monitorados. Se não abrir automaticamente, basta clicar no link fornecido.
 ::: 
 
-Após a implantação ser concluída, você receberá um domínio para acessar o seu projeto Astro na plataforma da Azion.
+Após a implantação ser concluída, você receberá um Workload para acessar o seu projeto Astro na plataforma da Azion.
 
-Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o domínio fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
+Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o Workload fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
 
 ---
 
@@ -152,6 +152,6 @@ Do you want to install project dependencies? This may be required to start local
 Uma vez que o deployment é iniciado, a Azion abrirá o navegador e levará o usuário a uma página no Azion Console onde os logs e o processo de implantação podem ser monitorados. Se não abrir automaticamente, basta clicar no link fornecido.
 ::: 
 
-Após a implantação ser concluída, você receberá um domínio para acessar o seu projeto Astro na plataforma da Azion.
+Após a implantação ser concluída, você receberá um Workload para acessar o seu projeto Astro na plataforma da Azion.
 
-Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o domínio fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
+Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o Workload fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.

--- a/src/content/docs/pt-br/pages/build-jornada/desenvolva-com-azion/guias-frameworks/framework-docusaurus.mdx
+++ b/src/content/docs/pt-br/pages/build-jornada/desenvolva-com-azion/guias-frameworks/framework-docusaurus.mdx
@@ -123,9 +123,9 @@ azion deploy
 Uma vez que o deployment é iniciado, a Azion abrirá o navegador e levará o usuário a uma página no Azion Console onde os logs e o processo de implantação podem ser monitorados. Se não abrir automaticamente, basta clicar no link fornecido.
 :::
 
-Após a implantação ser concluída, você receberá um domínio para acessar o seu projeto Docusaurus na plataforma da Azion.
+Após a implantação ser concluída, você receberá um Workload para acessar o seu projeto Docusaurus na plataforma da Azion.
 
-Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o domínio fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
+Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o Workload fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
 
 ---
 
@@ -151,6 +151,6 @@ Do you want to install project dependencies? This may be required to start local
 Uma vez que o deployment é iniciado, a Azion abrirá o navegador e levará o usuário a uma página no Azion Console onde os logs e o processo de implantação podem ser monitorados. Se não abrir automaticamente, basta clicar no link fornecido.
 ::: 
 
-Após a implantação ser concluída, você receberá um domínio para acessar o seu projeto Docusaurus na Plataforma da Azion.
+Após a implantação ser concluída, você receberá um Workload para acessar o seu projeto Docusaurus na Plataforma da Azion.
 
-Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o domínio fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
+Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o Workload fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.

--- a/src/content/docs/pt-br/pages/build-jornada/desenvolva-com-azion/guias-frameworks/framework-eleventy.mdx
+++ b/src/content/docs/pt-br/pages/build-jornada/desenvolva-com-azion/guias-frameworks/framework-eleventy.mdx
@@ -123,9 +123,9 @@ azion deploy
 Uma vez que o deployment é iniciado, a Azion abrirá o navegador e levará o usuário a uma página no Azion Console onde os logs e o processo de implantação podem ser monitorados. Se não abrir automaticamente, basta clicar no link fornecido.
 :::
 
-Após a implantação ser concluída, você receberá um domínio para acessar o seu projeto Eleventy na plataforma da Azion.
+Após a implantação ser concluída, você receberá um Workload para acessar o seu projeto Eleventy na plataforma da Azion.
 
-Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o domínio fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
+Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o Workload fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
 
 ---
 
@@ -151,6 +151,6 @@ Do you want to install project dependencies? This may be required to start local
 Uma vez que o deployment é iniciado, a Azion abrirá o navegador e levará o usuário a uma página no Azion Console onde os logs e o processo de implantação podem ser monitorados. Se não abrir automaticamente, basta clicar no link fornecido.
 ::: 
 
-Após a implantação ser concluída, você receberá um domínio para acessar o seu projeto Eleventy na Plataforma da Azion.
+Após a implantação ser concluída, você receberá um Workload para acessar o seu projeto Eleventy na Plataforma da Azion.
 
-Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o domínio fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
+Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o Workload fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.

--- a/src/content/docs/pt-br/pages/build-jornada/desenvolva-com-azion/guias-frameworks/framework-gatsby.mdx
+++ b/src/content/docs/pt-br/pages/build-jornada/desenvolva-com-azion/guias-frameworks/framework-gatsby.mdx
@@ -123,9 +123,9 @@ azion deploy
 Uma vez que o deployment é iniciado, a Azion abrirá o navegador e levará o usuário a uma página no Azion Console onde os logs e o processo de implantação podem ser monitorados. Se não abrir automaticamente, basta clicar no link fornecido.
 :::
 
-Após a implantação ser concluída, você receberá um domínio para acessar o seu projeto Gatsby na plataforma da Azion.
+Após a implantação ser concluída, você receberá um Workload para acessar o seu projeto Gatsby na plataforma da Azion.
 
-Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o domínio fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
+Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o Workload fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
 
 ---
 
@@ -151,6 +151,6 @@ Do you want to install project dependencies? This may be required to start local
 Uma vez que o deployment é iniciado, a Azion abrirá o navegador e levará o usuário a uma página no Azion Console onde os logs e o processo de implantação podem ser monitorados. Se não abrir automaticamente, basta clicar no link fornecido.
 ::: 
 
-Após a implantação ser concluída, você receberá um domínio para acessar o seu projeto Gatsby na Plataforma da Azion.
+Após a implantação ser concluída, você receberá um Workload para acessar o seu projeto Gatsby na Plataforma da Azion.
 
-Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o domínio fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
+Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o Workload fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.

--- a/src/content/docs/pt-br/pages/build-jornada/desenvolva-com-azion/guias-frameworks/framework-hexo.mdx
+++ b/src/content/docs/pt-br/pages/build-jornada/desenvolva-com-azion/guias-frameworks/framework-hexo.mdx
@@ -123,9 +123,9 @@ azion deploy
 Uma vez que o deployment é iniciado, a Azion abrirá o navegador e levará o usuário a uma página no Azion Console onde os logs e o processo de implantação podem ser monitorados. Se não abrir automaticamente, basta clicar no link fornecido.
 :::
 
-Após a implantação ser concluída, você receberá um domínio para acessar o seu projeto Hexo na plataforma da Azion.
+Após a implantação ser concluída, você receberá um Workload para acessar o seu projeto Hexo na plataforma da Azion.
 
-Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o domínio fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
+Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o Workload fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
 
 ---
 
@@ -151,6 +151,6 @@ Do you want to install project dependencies? This may be required to start local
 Uma vez que o deployment é iniciado, a Azion abrirá o navegador e levará o usuário a uma página no Azion Console onde os logs e o processo de implantação podem ser monitorados. Se não abrir automaticamente, basta clicar no link fornecido.
 ::: 
 
-Após a implantação ser concluída, você receberá um domínio para acessar o seu projeto Hexo na Plataforma da Azion.
+Após a implantação ser concluída, você receberá um Workload para acessar o seu projeto Hexo na Plataforma da Azion.
 
-Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o domínio fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
+Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o Workload fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.

--- a/src/content/docs/pt-br/pages/build-jornada/desenvolva-com-azion/guias-frameworks/framework-hono.mdx
+++ b/src/content/docs/pt-br/pages/build-jornada/desenvolva-com-azion/guias-frameworks/framework-hono.mdx
@@ -123,9 +123,9 @@ azion deploy
 Uma vez que o deployment é iniciado, a Azion abrirá o navegador e levará o usuário a uma página no Azion Console onde os logs e o processo de implantação podem ser monitorados. Se não abrir automaticamente, basta clicar no link fornecido.
 :::
 
-Após a implantação ser concluída, você receberá um domínio para acessar o seu projeto Hono na plataforma da Azion.
+Após a implantação ser concluída, você receberá um Workload para acessar o seu projeto Hono na plataforma da Azion.
 
-Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o domínio fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
+Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o Workload fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
 
 ---
 
@@ -151,6 +151,6 @@ Do you want to install project dependencies? This may be required to start local
 Uma vez que o deployment é iniciado, a Azion abrirá o navegador e levará o usuário a uma página no Azion Console onde os logs e o processo de implantação podem ser monitorados. Se não abrir automaticamente, basta clicar no link fornecido.
 ::: 
 
-Após a implantação ser concluída, você receberá um domínio para acessar o seu projeto Hono na Plataforma da Azion.
+Após a implantação ser concluída, você receberá um Workload para acessar o seu projeto Hono na Plataforma da Azion.
 
-Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o domínio fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
+Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o Workload fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.

--- a/src/content/docs/pt-br/pages/build-jornada/desenvolva-com-azion/guias-frameworks/framework-hugo.mdx
+++ b/src/content/docs/pt-br/pages/build-jornada/desenvolva-com-azion/guias-frameworks/framework-hugo.mdx
@@ -123,9 +123,9 @@ azion deploy
 Uma vez que o deployment é iniciado, a Azion abrirá o navegador e levará o usuário a uma página no Azion Console onde os logs e o processo de implantação podem ser monitorados. Se não abrir automaticamente, basta clicar no link fornecido.
 :::
 
-Após a implantação ser concluída, você receberá um domínio para acessar o seu projeto Hugo na plataforma da Azion.
+Após a implantação ser concluída, você receberá um Workload para acessar o seu projeto Hugo na plataforma da Azion.
 
-Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o domínio fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
+Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o Workload fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
 
 ---
 
@@ -151,6 +151,6 @@ Do you want to install project dependencies? This may be required to start local
 Uma vez que o deployment é iniciado, a Azion abrirá o navegador e levará o usuário a uma página no Azion Console onde os logs e o processo de implantação podem ser monitorados. Se não abrir automaticamente, basta clicar no link fornecido.
 ::: 
 
-Após a implantação ser concluída, você receberá um domínio para acessar o seu projeto Hugo na Plataforma da Azion.
+Após a implantação ser concluída, você receberá um Workload para acessar o seu projeto Hugo na Plataforma da Azion.
 
-Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o domínio fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
+Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o Workload fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.

--- a/src/content/docs/pt-br/pages/build-jornada/desenvolva-com-azion/guias-frameworks/framework-jekyll.mdx
+++ b/src/content/docs/pt-br/pages/build-jornada/desenvolva-com-azion/guias-frameworks/framework-jekyll.mdx
@@ -126,9 +126,9 @@ azion deploy
 Uma vez que o deployment é iniciado, a Azion abrirá o navegador e levará o usuário a uma página no Azion Console onde os logs e o processo de implantação podem ser monitorados. Se não abrir automaticamente, basta clicar no link fornecido.
 :::
 
-Após a implantação ser concluída, você receberá um domínio para acessar o seu projeto Jekyll na plataforma da Azion.
+Após a implantação ser concluída, você receberá um Workload para acessar o seu projeto Jekyll na plataforma da Azion.
 
-Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o domínio fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
+Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o Workload fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
 
 ---
 
@@ -154,6 +154,6 @@ Do you want to install project dependencies? This may be required to start local
 Uma vez que o deployment é iniciado, a Azion abrirá o navegador e levará o usuário a uma página no Azion Console onde os logs e o processo de implantação podem ser monitorados. Se não abrir automaticamente, basta clicar no link fornecido.
 ::: 
 
-Após a implantação ser concluída, você receberá um domínio para acessar o seu projeto Jekyll na Plataforma da Azion.
+Após a implantação ser concluída, você receberá um Workload para acessar o seu projeto Jekyll na Plataforma da Azion.
 
-Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o domínio fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
+Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o Workload fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.

--- a/src/content/docs/pt-br/pages/build-jornada/desenvolva-com-azion/guias-frameworks/framework-next.mdx
+++ b/src/content/docs/pt-br/pages/build-jornada/desenvolva-com-azion/guias-frameworks/framework-next.mdx
@@ -123,9 +123,9 @@ azion deploy
 Uma vez que o deployment é iniciado, a Azion abrirá o navegador e levará o usuário a uma página no Azion Console onde os logs e o processo de implantação podem ser monitorados. Se não abrir automaticamente, basta clicar no link fornecido.
 ::: 
 
-Após a implantação ser concluída, você receberá um domínio para acessar o seu projeto Next na plataforma da Azion.
+Após a implantação ser concluída, você receberá um Workload para acessar o seu projeto Next na plataforma da Azion.
 
-Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o domínio fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
+Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o Workload fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
 
 ### Resposta não para desenvolvimento local
 
@@ -149,9 +149,9 @@ Do you want to install project dependencies? This may be required to start local
 Uma vez que o deployment é iniciado, a Azion abrirá o navegador e levará o usuário a uma página no Azion Console onde os logs e o processo de implantação podem ser monitorados. Se não abrir automaticamente, basta clicar no link fornecido.
 ::: 
 
-Após a implantação ser concluída, você receberá um domínio para acessar o seu projeto Next na Plataforma da Azion.
+Após a implantação ser concluída, você receberá um Workload para acessar o seu projeto Next na Plataforma da Azion.
 
-Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o domínio fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
+Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o Workload fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
 
 ---
 

--- a/src/content/docs/pt-br/pages/build-jornada/desenvolva-com-azion/guias-frameworks/framework-react.mdx
+++ b/src/content/docs/pt-br/pages/build-jornada/desenvolva-com-azion/guias-frameworks/framework-react.mdx
@@ -129,9 +129,9 @@ azion deploy
 Uma vez que o deployment é iniciado, a Azion abrirá o navegador e levará o usuário a uma página no Azion Console onde os logs e o processo de implantação podem ser monitorados. Se não abrir automaticamente, basta clicar no link fornecido.
 ::: 
 
-Após a implantação ser concluída, você receberá um domínio para acessar o seu projeto React na plataforma da Azion.
+Após a implantação ser concluída, você receberá um Workload para acessar o seu projeto React na plataforma da Azion.
 
-Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o domínio fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
+Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o Workload fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
 
 ### Resposta não para desenvolvimento local
 
@@ -155,6 +155,6 @@ Do you want to install project dependencies? This may be required to start local
 Uma vez que o deployment é iniciado, a Azion abrirá o navegador e levará o usuário a uma página no Azion Console onde os logs e o processo de implantação podem ser monitorados. Se não abrir automaticamente, basta clicar no link fornecido.
 ::: 
 
-Após a implantação ser concluída, você receberá um domínio para acessar o seu projeto React na plataforma da Azion.
+Após a implantação ser concluída, você receberá um Workload para acessar o seu projeto React na plataforma da Azion.
 
-Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o domínio fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
+Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o Workload fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.

--- a/src/content/docs/pt-br/pages/build-jornada/desenvolva-com-azion/guias-frameworks/framework-svelte.mdx
+++ b/src/content/docs/pt-br/pages/build-jornada/desenvolva-com-azion/guias-frameworks/framework-svelte.mdx
@@ -130,9 +130,9 @@ azion deploy
 Uma vez que o deployment é iniciado, a Azion abrirá o navegador e levará o usuário a uma página no Azion Console onde os logs e o processo de implantação podem ser monitorados. Se não abrir automaticamente, basta clicar no link fornecido.
 :::
 
-Após a implantação ser concluída, você receberá um domínio para acessar o seu projeto Svelte na plataforma da Azion.
+Após a implantação ser concluída, você receberá um Workload para acessar o seu projeto Svelte na plataforma da Azion.
 
-Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o domínio fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
+Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o Workload fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
 
 ---
 
@@ -158,6 +158,6 @@ Do you want to install project dependencies? This may be required to start local
 Uma vez que o deployment é iniciado, a Azion abrirá o navegador e levará o usuário a uma página no Azion Console onde os logs e o processo de implantação podem ser monitorados. Se não abrir automaticamente, basta clicar no link fornecido.
 ::: 
 
-Após a implantação ser concluída, você receberá um domínio para acessar o seu projeto Svelte na Plataforma da Azion.
+Após a implantação ser concluída, você receberá um Workload para acessar o seu projeto Svelte na Plataforma da Azion.
 
-Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o domínio fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
+Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o Workload fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.

--- a/src/content/docs/pt-br/pages/build-jornada/desenvolva-com-azion/guias-frameworks/framework-vite.mdx
+++ b/src/content/docs/pt-br/pages/build-jornada/desenvolva-com-azion/guias-frameworks/framework-vite.mdx
@@ -128,9 +128,9 @@ azion deploy
 Uma vez que o deployment é iniciado, a Azion abrirá o navegador e levará o usuário a uma página no Azion Console onde os logs e o processo de implantação podem ser monitorados. Se não abrir automaticamente, basta clicar no link fornecido.
 ::: 
 
-Após a implantação ser concluída, você receberá um domínio para acessar o seu projeto VitePress na plataforma da Azion.
+Após a implantação ser concluída, você receberá um Workload para acessar o seu projeto VitePress na plataforma da Azion.
 
-Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o domínio fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
+Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o Workload fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
 
 ### Resposta não para desenvolvimento local
 
@@ -154,6 +154,6 @@ Do you want to install project dependencies? This may be required to start local
 Uma vez que o deployment é iniciado, a Azion abrirá o navegador e levará o usuário a uma página no Azion Console onde os logs e o processo de implantação podem ser monitorados. Se não abrir automaticamente, basta clicar no link fornecido.
 ::: 
 
-Após a implantação ser concluída, você receberá um domínio para acessar o seu projeto VitePress na Plataforma da Azion.
+Após a implantação ser concluída, você receberá um Workload para acessar o seu projeto VitePress na Plataforma da Azion.
 
-Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o domínio fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
+Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o Workload fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.

--- a/src/content/docs/pt-br/pages/build-jornada/desenvolva-com-azion/guias-frameworks/framework-vue.mdx
+++ b/src/content/docs/pt-br/pages/build-jornada/desenvolva-com-azion/guias-frameworks/framework-vue.mdx
@@ -130,9 +130,9 @@ azion deploy
 Uma vez que o deployment é iniciado, a Azion abrirá o navegador e levará o usuário a uma página no Azion Console onde os logs e o processo de implantação podem ser monitorados. Se não abrir automaticamente, basta clicar no link fornecido.
 ::: 
 
-Após a implantação ser concluída, você receberá um domínio para acessar o seu projeto Vue na plataforma da Azion.
+Após a implantação ser concluída, você receberá um Workload para acessar o seu projeto Vue na plataforma da Azion.
 
-Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o domínio fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
+Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o Workload fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
 
 ### Resposta não para desenvolvimento local
 
@@ -156,6 +156,6 @@ Do you want to install project dependencies? This may be required to start local
 Uma vez que o deployment é iniciado, a Azion abrirá o navegador e levará o usuário a uma página no Azion Console onde os logs e o processo de implantação podem ser monitorados. Se não abrir automaticamente, basta clicar no link fornecido.
 ::: 
 
-Após a implantação ser concluída, você receberá um domínio para acessar o seu projeto Vue na Plataforma da Azion.
+Após a implantação ser concluída, você receberá um Workload para acessar o seu projeto Vue na Plataforma da Azion.
 
-Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o domínio fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.
+Aguarde alguns minutos para que a propagação ocorra e, em seguida, acesse a sua aplicação usando o Workload fornecido, que deve ser semelhante a `https://xxxxxxx.map.azionedge.net`.


### PR DESCRIPTION
## Summary
- update frameworks docs to use **Workload** instead of domain

## Testing
- `npm run test:frontmatter`
